### PR TITLE
Specify the python version used by meseq in the shebang.

### DIFF
--- a/meseq.py
+++ b/meseq.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 # coding: utf-8
 import cairo
 import math


### PR DESCRIPTION
With that, those using a distribution where python3 is the default
python will be able to launch ./meseq.py directly.
